### PR TITLE
Use integer math inside hot loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ wheels/
 # venv
 .venv
 *.txt
+
+# cargo
+target/

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -31,6 +31,30 @@ bytemuck = "1.16.3"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 #log = { version = "0.4" }
 
+[[bin]]
+name = "hello"
+test = false
+bench = false
+
+[[bin]]
+name = "local"
+test = false
+bench = false
+
+[[bin]]
+name = "recorder"
+test = false
+bench = false
+
+[[bin]]
+name = "usb_custom"
+test = false
+bench = false
+
+[[bin]]
+name = "usb_serial"
+test = false
+bench = false
 
 [profile.dev]
 opt-level = "s"

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -50,14 +50,16 @@ fn generate_sine_cosine_table(
     num_samples: usize,
 ) -> String {
     let mut output = String::new();
-    output.push_str("pub const SINE_COSINE_TABLE: [(f32, f32); ");
+    output.push_str("pub const SINE_COSINE_TABLE: [(i32, i32); ");
     output.push_str(&num_samples.to_string());
     output.push_str("] = [\n");
 
+    let f_to_i32 = |x: f64| (x * i32::MAX as f64).round() as i32;
+
     for i in 0..num_samples {
         let angle = 2.0 * PI * signal_frequency * (i as f64 * (1.0 / sampling_frequency));
-        let sine = angle.sin() as f32;
-        let cosine = angle.cos() as f32;
+        let sine = f_to_i32(angle.sin());
+        let cosine = f_to_i32(angle.cos());
         output.push_str(&format!("    ({:?}, {:?}),\n", sine, cosine));
     }
 

--- a/firmware/src/bin/local.rs
+++ b/firmware/src/bin/local.rs
@@ -158,15 +158,15 @@ async fn main(_spawner: Spawner) {
             adc_transfer.await;
             pdm_transfer.request_stop();
 
-            let mut sum_sine: i64 = 0;
-            let mut sum_cosine: i64 = 0;
+            let mut sum_sine: i32 = 0;
+            let mut sum_cosine: i32 = 0;
 
             let adc_buf = unsafe { &ADC_BUF[..] };
 
             for i in 0..NUM_SAMPLES {
                 let (sine, cosine) = SINE_COSINE_TABLE[i];
-                sum_sine += adc_buf[i] as i64 * sine as i64;
-                sum_cosine += adc_buf[i] as i64 * cosine as i64;
+                sum_sine += adc_buf[i] as i32 * sine as i32;
+                sum_cosine += adc_buf[i] as i32 * cosine as i32;
             }
 
             let sum_sine = sum_sine as f32;

--- a/firmware/src/bin/local.rs
+++ b/firmware/src/bin/local.rs
@@ -158,16 +158,20 @@ async fn main(_spawner: Spawner) {
             adc_transfer.await;
             pdm_transfer.request_stop();
 
-            let mut sum_sine: f32 = 0.0;
-            let mut sum_cosine: f32 = 0.0;
+            let mut sum_sine: i64 = 0;
+            let mut sum_cosine: i64 = 0;
 
             let adc_buf = unsafe { &ADC_BUF[..] };
 
             for i in 0..NUM_SAMPLES {
                 let (sine, cosine) = SINE_COSINE_TABLE[i];
-                sum_sine += adc_buf[i] as f32 * sine;
-                sum_cosine += adc_buf[i] as f32 * cosine;
+                sum_sine += adc_buf[i] as i64 * sine as i64;
+                sum_cosine += adc_buf[i] as i64 * cosine as i64;
             }
+
+            let sum_sine = sum_sine as f32;
+            let sum_cosine = sum_cosine as f32;
+
             let phase = sum_sine.atan2(sum_cosine);
 
             phase_accumulator.update(phase);


### PR DESCRIPTION
Hi! Someone shared a link to you blog in the [embassy chat room](https://matrix.to/#/#embassy-rs:matrix.org), and I thought it was a really interesting project!

This patch replaces a bunch of slow softfloat math with a pair of [SMLAL](https://developer.arm.com/documentation/dui0473/m/arm-and-thumb-instructions/smlal) instructions per sample. This should allow for a much higher update rate, or more samples at the same rate to reduce noise. I suspect that it might also reduce rounding errors, but I'm not sure.

I don't have the hardware to test this, so please let me know how it works!

If it works well, I am also interested trying an integer version of atan2, such as [this one](https://docs.rs/idsp/0.15.1/idsp/fn.atan2.html) from the idsp crate.